### PR TITLE
fix(seo): clean up pagination indexing signals

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -1,6 +1,10 @@
 baseURL = "https://bedecarroll.com/"
 languageCode = "en-us"
-pagination.pagerSize = 5
+
+[pagination]
+disableAliases = true
+pagerSize = 5
+path = "page"
 
 # Required for Chroma and the custom syntax highlighting.
 [markup.highlight]
@@ -128,7 +132,7 @@ url = "/categories"
 path = "github.com/panr/hugo-theme-terminal/v4"
 
 [outputs]
-home = ["HTML", "AMP", "RSS"]
+home = ["HTML", "RSS"]
 
 [outputFormats.RSS]
 baseName = "feed"

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,0 +1,90 @@
+{{ $robots := "noodp" }}
+{{ if eq .Kind "404" }}
+  {{ $robots = "noindex, nofollow" }}
+{{ else if .Params.noindex }}
+  {{ if or (eq (.Param "noindex") true) (eq (.Param "noindex") "true") }}
+    {{ $robots = "noindex" }}
+  {{ end }}
+{{ end }}
+
+{{ $canonical := .Permalink }}
+{{ if and .IsNode (ne .Kind "404") }}
+  {{ $paginator := .Paginator }}
+  {{ if gt $paginator.PageNumber 1 }}
+    {{ $canonical = absURL $paginator.URL }}
+  {{ end }}
+{{ end }}
+
+<meta http-equiv="content-type" content="text/html; charset=utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="{{ if .IsHome }}{{ $.Site.Params.Subtitle }}{{ else if .Description}}{{ .Description | plainify }}{{ else }}{{ .Summary | plainify }}{{ end }}" />
+<meta name="keywords" content="{{ with .Params.Keywords }}{{ delimit . ", " }}{{ else }}{{ $.Site.Params.Keywords }}{{ end }}" />
+<meta name="robots" content="{{ $robots }}" />
+<link rel="canonical" href="{{ $canonical }}" />
+
+{{ template "_internal/google_analytics.html" . }}
+
+{{ $css := resources.Match "css/*.css" }}
+{{ range $css }}
+  {{ $styles := . | minify | fingerprint }}
+  <link rel="stylesheet" href="{{ $styles.Permalink }}">
+{{ end }}
+<!-- Custom Terminal.css styles -->
+{{ if (fileExists "static/terminal.css") -}}
+  <link rel="stylesheet" href="{{ "terminal.css" | absURL }}">
+{{- end }}
+<!-- Custom CSS to override theme properties (/static/style.css) -->
+{{ if (fileExists "static/style.css") -}}
+  <link rel="stylesheet" href="{{ "style.css" | absURL }}">
+{{- end }}
+
+<!-- Icons -->
+<link rel="shortcut icon" href="{{ "favicon.png" | absURL }}">
+<link rel="apple-touch-icon" href="{{ "apple-touch-icon.png" | absURL }}">
+
+<!-- Twitter Card -->
+<meta name="twitter:card" content="summary" />
+{{ if (isset $.Site.Params "twitter") }}
+  {{ if (isset $.Site.Params.Twitter "site") }}
+    <meta name="twitter:site" content="{{ $.Site.Params.Twitter.site }}" />
+  {{ end }}
+    <meta name="twitter:creator" content="{{ if .IsHome }}{{ $.Site.Params.Twitter.creator }}{{ else if isset .Params "authortwitter" }}{{ .Params.authorTwitter }}{{ else }}{{ .Params.Author }}{{ end }}" />
+{{ end }}
+
+<!-- OG data -->
+<meta property="og:locale" content="{{ $.Site.Language.Lang }}" />
+<meta property="og:type" content="{{ if .IsPage }}article{{ else }}website{{ end }}" />
+<meta property="og:title" content="{{ if .IsHome }}{{ $.Site.Title }}{{ else }}{{ .Title }}{{ end }}">
+<meta property="og:description" content="{{ if .IsHome }}{{ $.Site.Params.Subtitle }}{{ else if .Description}}{{ .Description | plainify }}{{ else }}{{ .Summary | plainify }}{{ end }}" />
+<meta property="og:url" content="{{ $canonical }}" />
+<meta property="og:site_name" content="{{ $.Site.Title }}" />
+{{ if (isset .Params "cover") }}
+  {{ $pageCover := .Param "cover" }}
+  {{ with (.Resources.GetMatch (.Param "cover")) }}
+    {{ $pageCover = .RelPermalink }}
+  {{ end }}
+  <meta property="og:image" content="{{ $pageCover | absURL }}">
+{{ else }}
+  <meta property="og:image" content="{{ "og-image.png" | absURL }}">
+{{ end }}
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="627">
+{{ range .Params.categories }}
+  <meta property="article:section" content="{{ . }}" />
+{{ end }}
+{{ if isset .Params "date" }}
+  <meta property="article:published_time" content="{{ time .Date }}" />
+{{ end }}
+
+<!-- RSS -->
+{{ with .OutputFormats.Get "RSS" }}
+  <link href="{{ .RelPermalink }}" rel="alternate" type="application/rss+xml" title="{{ $.Site.Title }}" />
+{{ end }}
+
+<!-- JSON Feed -->
+{{ with .OutputFormats.Get "json" }}
+  <link href="{{ .RelPermalink }}" rel="alternate" type="application/json" title="{{ $.Site.Title }}" />
+{{ end }}
+
+<!-- Extended head section-->
+{{ partial "extended_head.html" . }}


### PR DESCRIPTION
## Summary
- disable AMP output and first-page pagination aliases in Hugo config
- override the theme head partial to emit self-canonical URLs for paginated list pages
- mark the generated 404 page as `noindex, nofollow`

## Validation
- `hugo`
- `hugo --cleanDestinationDir`
- verified generated canonicals for `/page/2/`, `/posts/page/2/`, and taxonomy pagination
- verified no `page/1` alias pages and no AMP output remain in `public/`
